### PR TITLE
Update requirements to numpy 1.19.1 as min req

### DIFF
--- a/.github/workflows/build-whl-cibuild.yml
+++ b/.github/workflows/build-whl-cibuild.yml
@@ -37,13 +37,18 @@ jobs:
       - name: Install dependencies and cibuildwheel
         run: |
           python -m pip install cibuildwheel==2.4.0
-          python -m pip install -r requirements.txt
+          python -m pip install -r requirements-dev.txt
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
         env:
           # Disable building PyPy wheels on all platforms
           CIBW_SKIP: pp*
+          # Disable 32-bit compilation
+          CIBW_SKIP: "*-win32 *-manylinux_i686"
+          # Disable musllinux
+          CIBW_SKIP: "*-musllinux*"
+
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install wheel setuptools ninja
-        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
     
     - name: Build wheel
       run: python setup.py bdist_wheel
@@ -75,7 +75,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install wheel setuptools
-        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
     
     - name: Build source dist
       run: python setup.py sdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires=[
     "setuptools",
-    "numpy",
+    "numpy==1.19.1",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
-numpy
+numpy==1.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-numpy
+numpy>=1.19.1

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ with open("requirements.txt", "r") as fp:
 
 setup(
     name="numpymaxflow",
-    version="0.0.1",
+    version="0.0.2rc1",
     description="numpymaxflow: Max-flow/Min-cut in Numpy for 2D images and 3D volumes",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- update numpy to 1.19.1
- update cibuild to remove redundant opts
- bump to version 0.0.2rc1
- update build req to requirements-dev.txt for all build actions workflows